### PR TITLE
Prepopulate with filter values

### DIFF
--- a/assets/aui.editor.publish.js
+++ b/assets/aui.editor.publish.js
@@ -111,9 +111,22 @@
 			progressFrame = iframe[0];
 			window.requestAnimationFrame(indicateState);
 
+			//set pre-populate stuff here
+			if (field.data('filters') && Object.keys(field.data('filters')).length){
+				var qs = {prepopulate:{}};
+				var filters = field.data('filters');
+				for(var field in filters) {
+					var fieldid = $('*[name="fields['+field+']"],*[name="fields['+field+'][]"]').closest('.field').attr('id').substring(6);
+					qs.prepopulate[fieldid] = filters[field];
+				}
+				qs = '?' + $.param(qs);
+			} else {
+				qs ='';
+			}
+
 			// Load content
 			iframe.on('load.aui-editor', loadPage);
-			iframe.attr('src', link);
+			iframe.attr('src', link + qs);
 
 			// Prepare closing
 			editor.on('click.aui-editor', closeEditor);


### PR DESCRIPTION
This is meant to take advantage of association filters once implemented as discussed in the [this thread](https://github.com/symphonycms/symphony-2/issues/2322).

Allowing new entries created through the Association UI to pre-populate the filtered fields using the provided values.